### PR TITLE
Mobile Fixes

### DIFF
--- a/src/components/AstroCard.astro
+++ b/src/components/AstroCard.astro
@@ -22,7 +22,7 @@ const { href, title, body } = Astro.props;
                 >✋</span
             > HALT!
         </h1>
-        <p class="text-3xl text-center mb-6">
+        <p class="text-xl md:text-3xl text-center mb-6">
             {body}
         </p>
         <h2>

--- a/src/components/Blob.astro
+++ b/src/components/Blob.astro
@@ -51,7 +51,7 @@ const { height } = Astro.props;
 </script>
 
 <div
-    class=`overflow-hidden ${!!height ? 'h-[' + height + 'vh] w-[100vw] top-0 absolute' : ''}`>
+    class=`overflow-hidden ${!!height ? 'h-[' + height + 'vh] w-screen top-0 fixed' : ''}`>
     <div id="blob-main" class="bg-gradient-to-r from-violet-900 to-fuchsia-900">
     </div>
     <div id="blob-minor" class="bg-gradient-to-r from-pink-900 to-rose-900">
@@ -59,12 +59,12 @@ const { height } = Astro.props;
     <div id="blob-follow" class="hide"></div>
     <img
         alt=""
-        class="absolute w-[300vmin] max-w-none right-[-90vmin]"
+        class="fixed w-[300vmin] right-[-90vmin]"
         src="tailwind-blur.png"
     />
     <div
         id="blur"
-        class=`t-0 min-h-[100vh] ${!!height ? '' : 'h-[200vh]'} w-full absolute`>
+        class=`t-0 min-h-[100vh] ${!!height ? '' : 'h-[200vh]'} w-full fixed`>
     </div>
 </div>
 
@@ -79,7 +79,7 @@ const { height } = Astro.props;
             background-color: white;
             height: 100px;
             aspect-ratio: 1;
-            position: absolute;
+            position: fixed;
             translate: -50% -50%;
         }
 
@@ -90,7 +90,7 @@ const { height } = Astro.props;
         #blob-main {
             height: 50vmax;
             aspect-ratio: 1;
-            position: absolute;
+            position: fixed;
             left: -5%;
             top: 50%;
             scale: 1.2 0.9;
@@ -101,7 +101,7 @@ const { height } = Astro.props;
         #blob-minor {
             height: 70vmax;
             aspect-ratio: 1;
-            position: absolute;
+            position: fixed;
             left: -40%;
             top: -60%;
             scale: 1.2 1.1;

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -1,0 +1,10 @@
+---
+import {
+    Icon,
+} from './.';
+---
+
+<Icon
+    icon="logo"
+    class="!fill-slate-50 opacity-[0.015] absolute w-[130vmin] h-[130vmin] -rotate-12 top-[-5vmin] right-[-40vmin]"
+    />

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as Card } from './Card.astro';
 export { default as Footer } from './Footer.astro';
 export { default as Icon } from './Icon.astro';
 export { default as LessonPagination } from './LessonPagination.astro';
+export { default as Logo } from './Logo.astro';
 export { default as Navbar } from './Navbar.astro';
 export { default as NoisePanel } from './NoisePanel.astro';
 export { default as ScrollShow } from './ScrollShow.astro';

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,7 +25,7 @@ const META = {
 };
 ---
 
-<html class="!scroll-smooth bg-slate-900 overflow-x-hidden" lang="en">
+<html class="!scroll-smooth bg-slate-900 overflow-x-hidden relative" lang="en">
     <head>
         <SEO
             charset="UTF-8"
@@ -90,7 +90,7 @@ const META = {
             })()
         }
     </head>
-    <body class="bg-slate-900 -z-50 text-slate-50 w-[100vw]">
+    <body class="bg-slate-900 -z-50 text-slate-50 w-screen overflow-x-hidden relative">
         <slot />
         <ScrollUp />
     </body>

--- a/src/pages/[course].astro
+++ b/src/pages/[course].astro
@@ -41,8 +41,8 @@ import { Debug } from 'astro/components';
     <SkipToContent href="#1" />
     <Navbar path={`courses/${slug}`} />
     <div
-        class="footer-shadow absolute h-[100vh] w-[100vw] blur-sm brightness-[0.25] saturate-[0.7]"
-        style=`background-image: url(/thumb-${slug}.png); background-repeat: no-repeat; background-size: cover;`>
+        class="footer-shadow absolute h-screen w-screen blur-sm brightness-[0.25] saturate-[0.7]"
+        style=`background-image: url(/thumb-${slug}.png); background-repeat: no-repeat; background-size: cover; background-position: top`>
     </div>
     <div class="hero min-h-screen bg-transparent">
         <div class="hero-overlay bg-opacity-60"></div>

--- a/src/pages/courses.astro
+++ b/src/pages/courses.astro
@@ -2,7 +2,7 @@
 import '../css/global.css';
 import { getCollection } from 'astro:content';
 import Layout from '../layouts/Layout.astro';
-import { Blob, Navbar, Icon, Card, Footer, SkipToContent } from '../components';
+import { Blob, Navbar, Icon, Logo, Card, Footer, SkipToContent } from '../components';
 import { readTimeMins, readTimeReadable } from '../util/readTime';
 
 const courses = {
@@ -15,12 +15,9 @@ const courses = {
 <Layout title="Courses | Philosophy Distilled" slug="courses">
     <SkipToContent href="#cards" />
     <Blob height={100} />
-    <main class="bg-slate-900 text-slate-50 w-[100vw] min-h-[100vh] z-20">
+    <main class="bg-slate-900 text-slate-50 w-screen min-h-screen z-20 relative">
         <Navbar path="courses" />
-        <Icon
-            icon="logo"
-            class="!fill-slate-50 opacity-[0.015] absolute w-[130vmin] h-[130vmin] -rotate-12 right-[-40vmin] bottom-[-25vmin]"
-        />
+        <Logo />
         <div
             class="gridlines overflow-hidden grid place-items-center blur-none p-[5vw] w-[100vw] min-h-[100vh]">
             <ul

--- a/src/pages/courses.astro
+++ b/src/pages/courses.astro
@@ -19,7 +19,7 @@ const courses = {
         <Navbar path="courses" />
         <Logo />
         <div
-            class="gridlines overflow-hidden grid place-items-center blur-none p-[5vw] w-[100vw] min-h-[100vh]">
+            class="gridlines overflow-hidden grid place-items-center blur-none px-[5vw] pb-[5vw] pt-24 w-[100vw] min-h-[100vh]">
             <ul
                 class="flex flex-row justify-center flex-wrap gap-6 lg:gap-8 w-[90vw] mb-32">
                 <li class="text-sm">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import {
     Blob,
     Card,
     Icon,
+    Logo,
     Navbar,
     NoisePanel,
     Footer,
@@ -25,23 +26,19 @@ import Layout from '../layouts/Layout.astro';
 
 <Layout title="LiquidZulu | Philosophy Distilled" slug="index">
     <Blob />
-    <main class="bg-slate-900 text-slate-50 w-[100vw] overflow-hidden">
+    <main class="bg-slate-900 text-slate-50 w-screen">
         <SkipToContent href="#1" />
         <Navbar />
-        <Icon
-            icon="logo"
-            class="!fill-slate-50 opacity-[0.015] absolute w-[130vmin] h-[130vmin] -rotate-12 right-[-40vmin] bottom-[-25vmin]"
-        />
+        <Logo />
         <div class="gridlines blur-none w-[100vw]">
             <div class="h-[100svh] h-[100vh] top-0 grid place-items-center">
-                <div
-                    class="mx-6 flex flex-wrap w-full justify-center items-center">
+                <div class="mx-6 flex flex-wrap w-full justify-center items-center">
                     <!--mb-[-9vh]">-->
                     <div class="space-y-5 text-center grow">
                         <h1 class="text-slate-50 text-6xl font-black">
                             Philosophy Distilled
                         </h1>
-                        <h2 class="text-slate-300 text-3xl font-medium">
+                        <h2 class="text-slate-300 text-2xl md:text-3xl font-medium">
                             Your path to <span class="emphasis">expertise</span>
                             starts here.
                         </h2>


### PR DESCRIPTION
Played about with the CSS for a better mobile experience.
For some reason, mobile browsers don't respect the overflow property unless the html and body elements are relative.
The cards on the courses page are now guaranteed not to overlap with the navbar.
The position for course photos is now the top center (we may want this to be the center instead), rather than the top left, to get a better view of the image's main feature.
Reduced some font sizes for better readability on small screens.