### PR TITLE
resolves #81

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,11 +6,17 @@ import { visit } from 'unist-util-visit';
 import slugify from 'slugify';
 import { readdir } from 'node:fs/promises';
 import { regexReplace } from './src/util/regexReplace';
+import {
+    wikilinksToHypertextLinks,
+    wikilinksToMdLinks,
+} from './src/util/wikilinks';
 
 const files = await readdir('./src/content/brain');
 const filesProc = files
     .filter(file => !file.startsWith('.'))
     .map(file => file.split('.')[0]);
+
+const isObsidian = file => file.path.match(/content\/brain/g) !== null; // | check_for_some_other_vault
 
 export default defineConfig({
     experimental: {
@@ -19,49 +25,41 @@ export default defineConfig({
     site: 'https://liquidzulu.github.io',
     integrations: [tailwind(), prefetch()],
     markdown: {
-        // .four-oh-four
         remarkPlugins: [
-            remarkWikilink,
-            () => ast => {
-                // wouldn't this look so much nicer if js had some sort of piping syntax?
-                visit(ast, 'text', node =>
-                    Object.assign(node, {
-                        // replace -- with endash
-                        value: regexReplace(
-                            // replace --- with emdash
-                            regexReplace(
-                                // normalise text to have only --- and --, not any rendered dashes, which is contributed, I believe, by gfm
-                                regexReplace(node.value, /—/g, x => '--'),
-                                /---/g,
-                                x => '—'
+            () => (ast, file) => {
+                // only do these things on Obsidian vaults
+                if (isObsidian(file)) {
+                    // replace dashes
+                    // wouldn't this look so much nicer if js had some sort of piping syntax?
+                    visit(ast, 'text', node =>
+                        Object.assign(node, {
+                            // replace -- with endash
+                            value: regexReplace(
+                                // replace --- with emdash
+                                regexReplace(
+                                    // normalise text to have only --- and --, not any rendered dashes, which is contributed, I believe, by gfm
+                                    regexReplace(node.value, /—/g, x => '--'),
+                                    /---/g,
+                                    x => '—'
+                                ),
+                                /--/g,
+                                x => '–'
                             ),
-                            /--/g,
-                            x => '–'
-                        ),
-                    })
-                );
+                        })
+                    );
 
-                visit(ast, 'wikiLink', node =>
-                    Object.assign(node, {
-                        data: Object.assign(node.data, {
-                            hProperties: Object.assign(node.data.hProperties, {
-                                href: filesProc.some(e => e == node.data.target)
-                                    ? '/brain/note/' +
-                                      slugify(
-                                          node.data.hProperties.href
-                                      ).toLowerCase()
-                                    : '',
-                                className: filesProc.some(
-                                    e => e == node.data.target
-                                )
-                                    ? node.data.hProperties.className +
-                                      ' link-exists'
-                                    : node.data.hProperties.className +
-                                      ' link-doesnt-exist',
+                    // handle wikilinks
+                    visit(ast, 'text', node =>
+                        Object.assign(node, {
+                            type: 'html',
+                            value: wikilinksToHypertextLinks(node.value, {
+                                class: 'internal',
+                                files: filesProc,
+                                linkPreface: '/brain/note',
                             }),
-                        }),
-                    })
-                );
+                        })
+                    );
+                }
             },
         ],
     },

--- a/src/util/wikilinks.ts
+++ b/src/util/wikilinks.ts
@@ -17,11 +17,38 @@ export const wikilinksToMdLinks = (md: string): string =>
         )
     );
 
-export const wikilinksToHypertextLinks = (md: string): string =>
+export const wikilinksToHypertextLinks = (
+    md: string,
+    opts: {
+        class?: string;
+        files?: string[];
+        linkPreface?: string;
+    }
+): string =>
     regexReplace(md, wikilinkRegex, x =>
-        ((y: [string, string]) => `<a href="./${getSlug(y[0])}">${y[1]}</a>`)(
-            procWikilink(x)
-        )
+        ((y: [string, string]) =>
+            `<a${
+                opts.class
+                    ? ' class="' +
+                      opts.class +
+                      (opts.files
+                          ? opts.files.some(e => e == y[0])
+                              ? ' link-exists'
+                              : ' link-doesnt-exist'
+                          : '') +
+                      '"'
+                    : ''
+            } ${
+                opts.files
+                    ? opts.files.some(e => e == y[0])
+                        ? 'href="' +
+                          (opts.linkPreface ?? '.') +
+                          '/' +
+                          getSlug(y[0]) +
+                          '"'
+                        : /*404*/ 'title="This page has not been created yet"'
+                    : ''
+            } >${y[1]}</a>`)(procWikilink(x))
     );
 
 export const wikilinksToPlaintext = (md: string): string =>


### PR DESCRIPTION
Solved by applying the dash workaround only to Obsidian vaults and moving wikilink logic within that wrapper.