### PR TITLE
fix slugification logic

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,18 +3,18 @@ import tailwind from '@astrojs/tailwind';
 import prefetch from '@astrojs/prefetch';
 import remarkWikilink from '@portaljs/remark-wiki-link';
 import { visit } from 'unist-util-visit';
-import slugify from 'slugify';
 import { readdir } from 'node:fs/promises';
 import { regexReplace } from './src/util/regexReplace';
 import {
     wikilinksToHypertextLinks,
     wikilinksToMdLinks,
 } from './src/util/wikilinks';
+import { getSlug } from './src/util/getSlug';
 
 const files = await readdir('./src/content/brain');
 const filesProc = files
     .filter(file => !file.startsWith('.'))
-    .map(file => file.split('.')[0]);
+    .map(file => getSlug(file.split('.')[0]));
 
 const isObsidian = file => file.path.match(/content\/brain/g) !== null; // | check_for_some_other_vault
 

--- a/src/pages/brain/note/[note].astro
+++ b/src/pages/brain/note/[note].astro
@@ -3,6 +3,7 @@ import { ViewTransitions } from 'astro:transitions';
 import '../../../css/global.css';
 import { invert } from '../../../util/invert';
 import { hasTag } from '../../../util/hasTag';
+import { getSlug } from '../../../util/getSlug';
 import {
     wikilinksToHypertextLinks,
     wikilinksToMdLinks,

--- a/src/util/getSlug.ts
+++ b/src/util/getSlug.ts
@@ -1,2 +1,8 @@
 export const getSlug = (str: string): string =>
-    str.toLowerCase().replaceAll(' ', '-');
+    str
+        .toLowerCase()
+        .replaceAll(' ', '-')
+        .replaceAll(/[^a-z0-9\-]+/g, '');
+// .toLowerCase()
+// .replace(/[^a-z0-9]+/g, '-')
+// .replace(/(^-|-$)+/g, '');

--- a/src/util/wikilinks.ts
+++ b/src/util/wikilinks.ts
@@ -32,7 +32,7 @@ export const wikilinksToHypertextLinks = (
                     ? ' class="' +
                       opts.class +
                       (opts.files
-                          ? opts.files.some(e => e == y[0])
+                          ? opts.files.some(e => e == getSlug(y[0]))
                               ? ' link-exists'
                               : ' link-doesnt-exist'
                           : '') +
@@ -40,7 +40,7 @@ export const wikilinksToHypertextLinks = (
                     : ''
             } ${
                 opts.files
-                    ? opts.files.some(e => e == y[0])
+                    ? opts.files.some(e => e == getSlug(y[0]))
                         ? 'href="' +
                           (opts.linkPreface ?? '.') +
                           '/' +


### PR DESCRIPTION
The previous logic broke upon facing a file name with a `'` in it (for instance, `The Attack on the Senses by Eddington's Two Tables.md`). This fixes it by filtering out any non-slug friendly characters at the end of the pipeline. Also now needs to slugify the file comparison to determine if the note exists or not.