### PR TITLE
fix arrow regex

### DIFF
--- a/src/util/markdown-plugins.ts
+++ b/src/util/markdown-plugins.ts
@@ -22,15 +22,25 @@ export const [
     leftRightArrow,
 ]: Array<NodeNodeMap> = [
     node =>
-        nodeReplacer(node, node => regexReplace(node.value, /<-/g, x => '←')),
+        nodeReplacer(node, node =>
+            regexReplace(node.value, / <- /g, x => ' ← ')
+        ),
     node =>
-        nodeReplacer(node, node => regexReplace(node.value, /->/g, x => '→')),
+        nodeReplacer(node, node =>
+            regexReplace(node.value, / -> /g, x => ' → ')
+        ),
     node =>
-        nodeReplacer(node, node => regexReplace(node.value, /\|\^/g, x => '↑')),
+        nodeReplacer(node, node =>
+            regexReplace(node.value, / \|\^ /g, x => ' ↑ ')
+        ),
     node =>
-        nodeReplacer(node, node => regexReplace(node.value, /\|v/g, x => '↓')),
+        nodeReplacer(node, node =>
+            regexReplace(node.value, / \|v /g, x => ' ↓ ')
+        ),
     node =>
-        nodeReplacer(node, node => regexReplace(node.value, /<->/g, x => '↔')),
+        nodeReplacer(node, node =>
+            regexReplace(node.value, / <-> /g, x => ' ↔ ')
+        ),
 ];
 
 const arrowFns = [leftArrow, rightArrow, upArrow, downArrow, leftRightArrow];


### PR DESCRIPTION
Before a wikilink like `[[Validation|validated]]` would result in `[[Validation↓alidated]]`