### PR TITLE
use positive lookbehind on regex

### DIFF
--- a/src/util/wikilinks.ts
+++ b/src/util/wikilinks.ts
@@ -3,7 +3,7 @@ import { getSlug } from './getSlug';
 import { invertLinks } from './invert';
 import type { CollectionEntry } from 'astro:content';
 
-export const wikilinkRegex = /\[\[(([^\]\|]+)(\|[^\]]+)?)\]\]/g;
+export const wikilinkRegex = /(?<=\[)(\[)(([^\]\|]+)(\|[^\]]+)?)\]\]/g;
 
 export const procWikilink = (wikilink: string): [string, string] => {
     const proc = wikilink.replaceAll('[', '').replaceAll(']', '').split('|');


### PR DESCRIPTION
Previously the regex would match on every leading `[` of a wikilink, so if I have "Ayn Rand offers a new formulation of \[[[The Law of Identity|the law of identity]]\]:" it would remove the escaped `[` character. This lookbehind fixes this. Browser compatibility should not be an issue, because all of that bs is processed by node, so only one regex engine to care about.